### PR TITLE
Add TeamCity test adapter support and update NUKE common package

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="7.0.1" />
+    <PackageReference Include="Nuke.Common" Version="7.0.2" />
     <PackageDownload Include="GitVersion.Tool" version="[5.12.0]" />
     <PackageDownload Include="ReportGenerator" Version="[5.1.18]" />
   </ItemGroup>

--- a/samples/1-basic/build/_build.csproj
+++ b/samples/1-basic/build/_build.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="7.0.1" />
+    <PackageReference Include="Nuke.Common" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/2-format/build/_build.csproj
+++ b/samples/2-format/build/_build.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="7.0.1" />
+    <PackageReference Include="Nuke.Common" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/3-test/build/_build.csproj
+++ b/samples/3-test/build/_build.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="7.0.1" />
+    <PackageReference Include="Nuke.Common" Version="7.0.2" />
     <PackageDownload Include="ReportGenerator" Version="[5.1.19]" />
   </ItemGroup>
 

--- a/src/Components/Xerris.Nuke.Components.csproj
+++ b/src/Components/Xerris.Nuke.Components.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="7.0.1" />
+    <PackageReference Include="Nuke.Common" Version="7.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds support for the [TeamCity VSTest Adapter](https://github.com/JetBrains/TeamCity.VSTest.TestAdapter) and updates NUKE dependency to v7.0.2.