### PR TITLE
Fix issue with format target exclusions

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Nuke.Common;
 using Nuke.Common.CI;
+using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
@@ -36,7 +37,7 @@ partial class Build : NukeBuild,
     readonly Solution Solution;
     Solution IHasSolution.Solution => Solution;
 
-    public IEnumerable<string> ExcludedFormatPaths => Enumerable.Empty<string>();
+    public IEnumerable<AbsolutePath> ExcludedFormatPaths => Enumerable.Empty<AbsolutePath>();
 
     public bool RunFormatAnalyzers => true;
 

--- a/samples/2-format/build/Build.cs
+++ b/samples/2-format/build/Build.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Nuke.Common;
+using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Xerris.Nuke.Components;
 
@@ -20,7 +21,7 @@ class Build : NukeBuild, IFormat, ICompile
     readonly Solution Solution;
     Solution IHasSolution.Solution => Solution;
 
-    public IEnumerable<string> ExcludedFormatPaths => Enumerable.Empty<string>();
+    public IEnumerable<AbsolutePath> ExcludedFormatPaths => Enumerable.Empty<AbsolutePath>();
 
     Target ICompile.Compile => _ => _
         .Inherit<ICompile>()

--- a/samples/3-test/tests/Library/Xerris.Nuke.Samples.Test.Library.Tests/Xerris.Nuke.Samples.Test.Library.Tests.csproj
+++ b/samples/3-test/tests/Library/Xerris.Nuke.Samples.Test.Library.Tests/Xerris.Nuke.Samples.Test.Library.Tests.csproj
@@ -13,19 +13,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="ReportGenerator" Version="5.1.20" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="ReportGenerator" Version="5.1.23" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Components/IFormat.cs
+++ b/src/Components/IFormat.cs
@@ -1,4 +1,5 @@
 using Nuke.Common;
+using Nuke.Common.IO;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 namespace Xerris.Nuke.Components;
@@ -9,9 +10,10 @@ namespace Xerris.Nuke.Components;
 public interface IFormat : IHasSolution
 {
     /// <summary>
-    /// Paths to exclude from formatting and formatting verification.
+    /// Paths to exclude from formatting and formatting verification. Paths must be relative to the build's root
+    /// directory (<see cref="NukeBuild.RootDirectory"/>)
     /// </summary>
-    IEnumerable<string> ExcludedFormatPaths { get; }
+    IEnumerable<AbsolutePath> ExcludedFormatPaths { get; }
 
     /// <summary>
     /// Whether or not to run third-party analyzers as part of formatting verification.
@@ -31,18 +33,17 @@ public interface IFormat : IHasSolution
         .Executes(() =>
         {
             DotNet($"format whitespace {Solution.Path} " +
-                $"--verify-no-changes " +
-                $"{ExcludedPathsArgument}");
+                "--verify-no-changes " +
+                ExcludedPathsArgument);
 
             DotNet($"format style {Solution.Path} " +
-                $"--verify-no-changes " +
-                $"{ExcludedPathsArgument}");
-
+                "--verify-no-changes " +
+                ExcludedPathsArgument);
             if (RunFormatAnalyzers)
             {
                 DotNet($"format analyzers {Solution.Path} " +
-                    $"--verify-no-changes " +
-                    $"{ExcludedPathsArgument}");
+                    "--verify-no-changes " +
+                    ExcludedPathsArgument);
             }
         });
 

--- a/tests/Components/Xerris.Nuke.Components.Tests.csproj
+++ b/tests/Components/Xerris.Nuke.Components.Tests.csproj
@@ -13,19 +13,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="ReportGenerator" Version="5.1.20" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="ReportGenerator" Version="5.1.23" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Fixes issue with templating of command sent to `dotnet format` when excluded paths are specified. Also changed format path exclusions to use AbsolutePaths instead of strings for compatibility across platforms.